### PR TITLE
Potential fix for code scanning alert no. 110: Uncontrolled data used in path expression

### DIFF
--- a/lpm_kernel/L2/utils.py
+++ b/lpm_kernel/L2/utils.py
@@ -357,7 +357,11 @@ def save_hf_model(model_name="Qwen2.5-0.5B-Instruct", log_file_path=None) -> str
     # Setup logging
     logger = setup_logger(log_file_path)
     
-    save_path = os.path.join(os.getcwd(), "resources/L2/base_models", model_name)
+    base_dir = os.path.join(os.getcwd(), "resources/L2/base_models")
+    normalized_model_name = os.path.normpath(model_name)
+    if ".." in normalized_model_name or normalized_model_name.startswith("/"):
+        raise ValueError("Invalid model name")
+    save_path = os.path.join(base_dir, normalized_model_name)
     os.makedirs(save_path, exist_ok=True)
 
     from huggingface_hub import list_repo_files, configure_http_backend


### PR DESCRIPTION
Potential fix for [https://github.com/umutcrs/Second-Me/security/code-scanning/110](https://github.com/umutcrs/Second-Me/security/code-scanning/110)

To fix the problem, we need to validate the `model_name` parameter to ensure it does not contain any malicious path components. We can achieve this by normalizing the path and ensuring it remains within the intended directory. Additionally, we can use a whitelist of allowed model names if applicable.

1. Normalize the `model_name` using `os.path.normpath`.
2. Ensure the normalized path does not contain any directory traversal components (e.g., `..`).
3. Optionally, restrict the `model_name` to a predefined set of allowed names.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
