### PR TITLE
Potential fix for code scanning alert no. 109: Uncontrolled data used in path expression

### DIFF
--- a/lpm_kernel/api/domains/trainprocess/routes.py
+++ b/lpm_kernel/api/domains/trainprocess/routes.py
@@ -2,7 +2,7 @@ import json
 import logging
 import time
 from pathlib import Path
-
+from werkzeug.utils import secure_filename
 from flask import Blueprint, jsonify, Response, request
 
 from lpm_kernel.file_data.trainprocess_service import TrainProcessService
@@ -170,9 +170,10 @@ def stream_logs():
 @trainprocess_bp.route("/progress/<model_name>", methods=["GET"])
 def get_progress(model_name):
     """Get current progress (non-real-time)"""
-    progress_name = f'trainprocess_progress_{model_name}.json'  # Build filename based on the provided model_name
+    sanitized_model_name = secure_filename(model_name)  # Sanitize model_name
+    progress_name = f'trainprocess_progress_{sanitized_model_name}.json'  # Build filename based on the sanitized model_name
     try:
-        train_service = TrainProcessService(progress_file=progress_name, model_name=model_name)  # Pass in specific progress file
+        train_service = TrainProcessService(progress_file=progress_name, model_name=sanitized_model_name)  # Pass in specific progress file
         progress = train_service.progress.progress
 
         return jsonify(

--- a/lpm_kernel/file_data/trainprocess_service.py
+++ b/lpm_kernel/file_data/trainprocess_service.py
@@ -95,7 +95,9 @@ class Progress:
         progress_dir = os.path.join(os.getcwd(), "data/progress")
         if not os.path.exists(progress_dir):
             os.makedirs(progress_dir)
-        self.progress_file = os.path.join(progress_dir, progress_file)
+        self.progress_file = os.path.normpath(os.path.join(progress_dir, progress_file))
+        if not self.progress_file.startswith(progress_dir):
+            raise ValueError("Invalid progress file path")
         self.progress = TrainProgress()
         self.progress_callback = progress_callback
         self.logger = logging.getLogger(__name__)


### PR DESCRIPTION
Potential fix for [https://github.com/umutcrs/Second-Me/security/code-scanning/109](https://github.com/umutcrs/Second-Me/security/code-scanning/109)

To fix the problem, we need to validate and sanitize the `model_name` parameter before using it to construct the `progress_file` path. We can use the `werkzeug.utils.secure_filename` function to ensure that the `model_name` does not contain any special characters or path traversal sequences. Additionally, we should normalize the constructed path and ensure it is within the intended directory.

1. Import the `secure_filename` function from `werkzeug.utils`.
2. Use `secure_filename` to sanitize the `model_name` before constructing the `progress_file` name.
3. Normalize the constructed path and ensure it is within the `data/progress` directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
